### PR TITLE
Add prepareForParentEvents, and remove viewModel's controller-lifecycle.

### DIFF
--- a/RxController/Classes/RxViewController.swift
+++ b/RxController/Classes/RxViewController.swift
@@ -29,10 +29,6 @@ import RxCocoa
 
 protocol RxViewControllerProtocol {
     var rxViewModel: RxViewModel { get }
-    
-    func didMove(toParent parent: UIViewController?)
-    func addChild(_ childVC: UIViewController)
-    func addChild(_ childController: UIViewController, to containerView: UIView)
 }
 
 open class RxViewController<ViewModel: RxViewModel>: UIViewController, RxViewControllerProtocol {
@@ -57,31 +53,6 @@ open class RxViewController<ViewModel: RxViewModel>: UIViewController, RxViewCon
         Log.debug("[DEINIT View Controller] \(type(of: self))")
     }
     
-    open override func viewDidLoad() {
-        super.viewDidLoad()
-        viewModel.controllerDidLoad()
-    }
-    
-    open override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel.controllerDidAppear()
-    }
-    
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        viewModel.controllerDidDisappear()
-    }
-    
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.controllerWillAppear()
-    }
-    
-    open override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        viewModel.controllerWillDisappear()
-    }
-
     /**
      Add a child view controller to the root view of the parent view controller.
 

--- a/RxController/Classes/RxViewModel.swift
+++ b/RxController/Classes/RxViewModel.swift
@@ -46,15 +46,7 @@ open class RxViewModel: NSObject, Stepper {
         Log.debug("[DEINIT View Model] \(type(of: self))")
     }
     
-    open func controllerDidLoad() {}
-    
-    open func controllerDidAppear() {}
-    
-    open func controllerDidDisappear() {}
-    
-    open func controllerWillAppear() {}
-    
-    open func controllerWillDisappear() {}
+    open func prepareForParentEvents() {}
     
     public func addChildModel(_ viewModel: RxViewModel) {
         viewModel._parentEvents = events
@@ -66,11 +58,15 @@ open class RxViewModel: NSObject, Stepper {
         }
     }
     
-    weak var _parentEvents: PublishRelay<RxControllerEvent>?
+    weak var _parentEvents: PublishRelay<RxControllerEvent>? {
+        didSet {
+            prepareForParentEvents()
+        }
+    }
     
     public var parentEvents: PublishRelay<RxControllerEvent> {
         guard let events = _parentEvents else {
-            Log.debug("No prerent events found in \(type(of: self))!")
+            Log.debug("parentEvents have NOT been prepared in \(type(of: self))!\n use prepareForParentEvents if you subscribed parentEvents.")
             return PublishRelay()
         }
         return events


### PR DESCRIPTION
ViewModel shouldn't have a life cycle like ViewController.