### PR TITLE
add static function to RxFlow Contributors

### DIFF
--- a/Example/RxController/Controller/MenuViewModel.swift
+++ b/Example/RxController/Controller/MenuViewModel.swift
@@ -13,11 +13,12 @@ import RxSwift
 
 private extension Selection {
     static let childController = Selection(title: "Child View Controller Test")
+    static let childNavigationController = Selection(title: "Child View Controller on Navigation Test")
 }
 
 class MenuViewModel: RxViewModel {
     
-    private let selectionsRelay = BehaviorRelay<[Selection]>(value: [.childController])
+    private let selectionsRelay = BehaviorRelay<[Selection]>(value: [.childController, .childNavigationController])
     
     var selectionSection: Observable<SingleSection<Selection>> {
         return selectionsRelay.map {
@@ -32,6 +33,8 @@ class MenuViewModel: RxViewModel {
         switch selectionsRelay.value[index] {
         case .childController:
             steps.accept(AppStep.child)
+        case .childNavigationController:
+            steps.accept(AppStep.childOnNavigation)
         default:
             break
         }

--- a/Example/RxController/Flow/AppFlow.swift
+++ b/Example/RxController/Flow/AppFlow.swift
@@ -12,6 +12,7 @@ import RxFlow
 enum AppStep: Step {
     case start
     case child
+    case childOnNavigation
     case childIsComplete
 }
 
@@ -39,6 +40,7 @@ class AppFlow: Flow {
             let menuViewController = MenuViewController(viewModel: .init())
             navigationController.pushViewController(menuViewController, animated: false)
             return .viewController(menuViewController)
+            
         case .child:
             guard let menuViewController = navigationController.topViewController as? MenuViewController else {
                 return .none
@@ -46,14 +48,21 @@ class AppFlow: Flow {
             let infoViewController = InfoViewController(viewModel: InfoViewModel())
             menuViewController.present(infoViewController, animated: true)
             return .viewController(infoViewController)
-        case .childIsComplete:
-            guard
-                let menuViewController = navigationController.topViewController as? MenuViewController,
-                let infoViewController = menuViewController.presentedViewController as? InfoViewController
-            else {
+            
+        case .childOnNavigation:
+            guard let menuViewController = navigationController.topViewController as? MenuViewController else {
                 return .none
             }
-            infoViewController.dismiss(animated: true)
+            let infoViewController = InfoViewController(viewModel: InfoViewModel())
+            let navigation = UINavigationController(rootViewController: infoViewController)
+            menuViewController.present(navigation, animated: true)
+            return .viewController(navigation, with: infoViewController.viewModel)
+
+        case .childIsComplete:
+            guard let menuViewController = navigationController.topViewController as? MenuViewController else {
+                return .none
+            }
+            menuViewController.presentedViewController?.dismiss(animated: true)
             return .none
         }
     }

--- a/RxController/Classes/RxFlow+Extension.swift
+++ b/RxController/Classes/RxFlow+Extension.swift
@@ -31,6 +31,10 @@ extension FlowContributors {
         return .one(flowContributor: .viewController(viewController))
     }
     
+    public static func viewController(_ viewController: UIViewController, with viewModel: Stepper) -> FlowContributors {
+        return .one(flowContributor: .viewController(viewController, with: viewModel))
+    }
+    
     public static func flow(_ flow: Flow, with step: Step) -> FlowContributors {
         return .one(flowContributor: .flow(flow, with: step))
     }


### PR DESCRIPTION
Contributorsに、次画面と次ステッパーが一致しない場合のstatic functionも追加しました。

-----

ちなみに、PresentするときにFlowを経由させる必要はなかったです。
Presentでメモリリークする問題の原因は、UINavigationControllerで包んだRxViewControllerをpresentする際の書き方にありました。

flowの`func navigate(to step: Step) -> FlowContributors`で返すContributorsは次の「画面(Presentable)」「ステッパー(Stepper)」でなければならないのですが、
安易に`return .viewcontroller(~RxViewController~)`を使うと、下記NGパターンになってしまいます。

OK🙆
- Presentable: presentするUINavigationController
- Stepper: RxViewControllerのViewModel

NG🙅
- Presentable:  RxViewController（←Flow的には次の画面ではない！）
- Stepper: RxViewControllerのViewModel